### PR TITLE
Ensure collectors variable is initialised

### DIFF
--- a/pg_view.py
+++ b/pg_view.py
@@ -3115,14 +3115,14 @@ def main():
                     'pid': ppid,
                     'pgcon': pgcon,
                 })
+    collectors = []
+    groups = {}
     try:
         if len(clusters) == 0:
             logger.error('No suitable PostgreSQL instances detected, exiting...')
             logger.error('hint: use -v for details, or specify connection parameters manually in the configuration file (-c)')
             sys.exit(1)
 
-        collectors = []
-        groups = {}
         collectors.append(HostStatCollector())
         collectors.append(SystemStatCollector())
         collectors.append(MemoryStatCollector())


### PR DESCRIPTION
If no instances are detected by pg_view.py then `UnboundLocalError` occurs in the finally clause of main(). 

```
No suitable PostgreSQL instances detected, exiting...
hint: use -v for details, or specify connection parameters manually in the configuration file (-c)
Traceback (most recent call last):
  File "./pg_view.py", line 3161, in <module>
    main()
  File "./pg_view.py", line 3152, in main
    for c in collectors:
UnboundLocalError: local variable 'collectors' referenced before assignment
```

To fix this initialise the `collectors` variable outside the try block, guaranteeing it's initialised before the finally: block can execute.
