### PR TITLE
Automated travis ci builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+pg_view.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.4"
+  - "2.7"
+script:
+  - python -m doctest -v pg_view.py
+  - flake8 pg_view.py

--- a/pg_view.py
+++ b/pg_view.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import stat
 import sys
 import glob
 import getpass
@@ -1691,8 +1690,8 @@ class PartitionStatCollector(StatCollector):
         self.dbver = dbversion
         self.queue_consumer = consumer
         self.work_directory = work_directory
-        self.df_list_transformation = [{'out': 'dev', 'in': 0, 'fn': self._dereference_dev_name}, {'out': 'space_total'
-                                       , 'in': 1, 'fn': int}, {'out': 'space_left', 'in': 2, 'fn': int}]
+        self.df_list_transformation = [{'out': 'dev', 'in': 0, 'fn': self._dereference_dev_name}, {'out': 'space_total',
+                                        'in': 1, 'fn': int}, {'out': 'space_left', 'in': 2, 'fn': int}]
         self.io_list_transformation = [{'out': 'sectors_read', 'in': 5, 'fn': int}, {'out': 'sectors_written', 'in': 9,
                                        'fn': int}, {'out': 'await', 'in': 13, 'fn': int}]
         self.du_list_transformation = [{'out': 'path_size', 'in': 0, 'fn': int}, {'out': 'path', 'in': 1}]
@@ -2576,7 +2575,7 @@ class CursesOutput(object):
 
         layout = {}
         # get only the columns that are not hidden
-        col_remaining = [name for name in colnames if not name in colhidden]
+        col_remaining = [name for name in colnames if name not in colhidden]
         # calculate the available screen X dimensions and the width required by all columns
         width_available = self.screen_x - (xstart + 1)
         # we add width of all N fields + N-1 spaces between fields
@@ -3004,6 +3003,7 @@ def pick_connection_arguments(conn_args):
                 (result['host'], result['port']) = arg
                 break
     return result
+
 
 def can_connect_with_connection_arguments(host, port):
     """ check that we can connect given the specified arguments """

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=120


### PR DESCRIPTION
This PR will add Travis CI config and fixes minor flake8 issues (but not all of them).

Remaining flake8 formatting issues are:

./pg_view.py:114:121: E501 line too long (133 > 120 characters)
./pg_view.py:198:18: E126 continuation line over-indented for hanging indent
./pg_view.py:316:121: E501 line too long (138 > 120 characters)
./pg_view.py:428:121: E501 line too long (130 > 120 characters)
./pg_view.py:1241:121: E501 line too long (121 > 120 characters)
./pg_view.py:1255:121: E501 line too long (129 > 120 characters)
./pg_view.py:1302:121: E501 line too long (135 > 120 characters)
./pg_view.py:1694:41: E128 continuation line under-indented for visual indent
./pg_view.py:2479:21: E125 continuation line with same indent as next logical line
./pg_view.py:2862:121: E501 line too long (123 > 120 characters)
./pg_view.py:3043:121: E501 line too long (123 > 120 characters)
./pg_view.py:3048:121: E501 line too long (154 > 120 characters)
./pg_view.py:3062:121: E501 line too long (130 > 120 characters)
./pg_view.py:3099:121: E501 line too long (153 > 120 characters)
./pg_view.py:3181:121: E501 line too long (123 > 120 characters)
./pg_view.py:3236:121: E501 line too long (131 > 120 characters)
./pg_view.py:3274:121: E501 line too long (125 > 120 characters)
./pg_view.py:3398:17: E128 continuation line under-indented for visual indent
./pg_view.py:3399:17: E128 continuation line under-indented for visual indent
./pg_view.py:3402:21: E128 continuation line under-indented for visual indent
./pg_view.py:3403:21: E128 continuation line under-indented for visual indent
