### PR TITLE
Do not truncate the query containing the '|' char.

### DIFF
--- a/pg_view.py
+++ b/pg_view.py
@@ -468,7 +468,7 @@ class StatCollector(object):
             This kind of trimming seems to be better than tail trimming for user and database names.
         """
 
-        half = (maxw - 2) / 2
+        half = int((maxw - 2) / 2)
         return val[:half] + '..' + val[-half:]
 
     def _do_refresh(self, new_rows):

--- a/pg_view.py
+++ b/pg_view.py
@@ -167,7 +167,7 @@ class StatCollector(object):
         'column_header': COLHEADER.ch_default,
     }
 
-    NCURSES_CUSTOM_OUTPUT_FIELDS = ['header', 'prefix', 'append_column_headers']
+    NCURSES_CUSTOM_OUTPUT_FIELDS = ['header', 'prefix', 'prepend_column_headers']
 
     def __init__(self, ticks_per_refresh=1, produce_diffs=True):
         self.rows_prev = []
@@ -457,7 +457,7 @@ class StatCollector(object):
         if output_data.get('maxw', 0) > 0 and not self.notrim and len(str(val)) > output_data['maxw']:
             # if the value is larger than the maximum allowed width - trim it by removing chars from the middle
             val = self._trim_text_middle(val, output_data['maxw'])
-        if self.ncurses_custom_fields.get('append_column_headers') or output_data.get('column_header',
+        if self.ncurses_custom_fields.get('prepend_column_headers') or output_data.get('column_header',
            COLHEADER.ch_default) == COLHEADER.ch_prepend:
             header_position = COLHEADER.ch_prepend
         elif output_data.get('column_header', COLHEADER.ch_default) == COLHEADER.ch_append:
@@ -765,7 +765,7 @@ class StatCollector(object):
             minw = col.get('minw', 0)
             attname = self._produce_output_name(col)
             # XXX:  if append_column_header, min width should include the size of the attribut name
-            if method == OUTPUT_METHOD.curses and self.ncurses_custom_fields.get('append_column_headers'):
+            if method == OUTPUT_METHOD.curses and self.ncurses_custom_fields.get('prepend_column_headers'):
                 minw += len(attname) + 1
             col['w'] = len(attname)
             # use cooked values
@@ -1643,7 +1643,7 @@ class SystemStatCollector(StatCollector):
         self.previos_total_cpu_time = 0
         self.current_total_cpu_time = 0
         self.cpu_time_diff = 0
-        self.ncurses_custom_fields = {'header': False, 'prefix': 'sys: ', 'append_column_headers': True}
+        self.ncurses_custom_fields = {'header': False, 'prefix': 'sys: ', 'prepend_column_headers': True}
 
         self.postinit()
 
@@ -1991,7 +1991,7 @@ class MemoryStatCollector(StatCollector):
             },
         ]
 
-        self.ncurses_custom_fields = {'header': False, 'prefix': 'mem: ', 'append_column_headers': True}
+        self.ncurses_custom_fields = {'header': False, 'prefix': 'mem: ', 'prepend_column_headers': True}
 
         self.postinit()
 
@@ -2096,7 +2096,7 @@ class HostStatCollector(StatCollector):
             },
         ]
 
-        self.ncurses_custom_fields = {'header': False, 'prefix': None, 'append_column_headers': False}
+        self.ncurses_custom_fields = {'header': False, 'prefix': None, 'prepend_column_headers': False}
 
         self.postinit()
 
@@ -2482,7 +2482,7 @@ class CursesOutput(object):
         statuses = self.data[collector]['statuses']
         align = self.data[collector]['align']
         header = self.data[collector].get('header', False) or False
-        append_column_headers = self.data[collector].get('append_column_headers', False)
+        prepend_column_headers = self.data[collector].get('prepend_column_headers', False)
         highlights = self.data[collector]['highlights']
         types = self.data[collector]['types']
 
@@ -2516,7 +2516,7 @@ class CursesOutput(object):
             for field in layout:
                 # calculate colors and alignment for the data value
                 column_alignment = (align.get(field,
-                                    COLALIGN.ca_none) if not append_column_headers else COLALIGN.ca_left)
+                                    COLALIGN.ca_none) if not prepend_column_headers else COLALIGN.ca_left)
                 w = layout[field]['width']
                 # now check if we need to add ellipsis to indicate that the value has been truncated.
                 # we don't do this if the value is less than a certain length or when the column is marked as

--- a/pg_view.py
+++ b/pg_view.py
@@ -50,11 +50,6 @@ except ImportError:
     print('Unable to import ncurses, curses output will be unavailable')
     curses_available = False
 
-# bail out if we are not running Linux
-if platform.system() != 'Linux':
-    print('Non Linux database hosts are not supported at the moment. Can not continue')
-    sys.exit(243)
-
 
 # enum emulation
 
@@ -2528,7 +2523,8 @@ class CursesOutput(object):
                 else:
                     header, text = row[field].header, row[field].value
                 text = self._align_field(text, header, w, column_alignment, types.get(field, COLTYPES.ct_string))
-                color_fields = self.color_text(status[field], highlights[field], text, header, row[field].header_position)
+                color_fields = self.color_text(status[field], highlights[field],
+                                               text, header, row[field].header_position)
                 for f in color_fields:
                     self.screen.addnstr(self.next_y, layout[field]['start'] + f['start'], f['word'], f['width'],
                                         f['color'])
@@ -3308,6 +3304,11 @@ class ProcNetParser():
 
 def main():
     global TICK_LENGTH, logger, options
+
+    # bail out if we are not running Linux
+    if platform.system() != 'Linux':
+        print('Non Linux database hosts are not supported at the moment. Can not continue')
+        sys.exit(243)
 
     if not psycopg2_available:
         print('Unable to import psycopg2 module, please, install it (python-psycopg2). Can not continue')

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ class PyTest(TestCommand):
         params = {'args': self.test_args}
         if self.cov:
             params['args'] += self.cov
-            params['plugins'] = ['cov']
         params['args'] += ['--doctest-modules', MAIN_MODULE + '.py', '-s', '-vv']
         errno = pytest.main(**params)
         sys.exit(errno)


### PR DESCRIPTION
pg_view used to serialize both the column name and value into the string,
delimiting them by the '|' char, and deserialize them before the output in
order to calculate the layout and color of the value and, if necessary, the
header. That obvisouly did not work if the string contained '|' characters,
i.e. for a query doing string appends. Since there is no need for
serialization between the collectors and the output code (they are running on
the same system, and even if they were not, there are better ways), the format
was changed to the named tuple, containing the header name, value and the position
of the header relative to the value.

This fixes another problem - for the headers before the values pg_view used to
errorneously highlight the header if the value reached the warning or critical
threshold.