### PR TITLE
Add reconnect parameter for PgstatCollector

### DIFF
--- a/pg_view.py
+++ b/pg_view.py
@@ -225,7 +225,7 @@ class StatCollector(object):
         proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         ret = proc.wait()
         if ret != 0:
-            logger.debug('The command {cmd} returned a non-zero exit code'.format(cmd=cmdline))
+            logger.info('The command {cmd} returned a non-zero exit code'.format(cmd=cmdline))
         return ret, proc.stdout.read().strip()
 
     @staticmethod
@@ -1104,7 +1104,7 @@ class PgstatCollector(StatCollector):
         ppid = self.postmaster_pid
         result = self.exec_command_with_output('ps -o pid --ppid {0} --noheaders'.format(ppid))
         if result[0] != 0:
-            logger.debug("Couldn't determine the pid of subprocesses for {0}".format(ppid))
+            logger.info("Couldn't determine the pid of subprocesses for {0}".format(ppid))
             self.pids = []
         self.pids = [int(x) for x in result[1].split()]
 

--- a/pg_view.py
+++ b/pg_view.py
@@ -2864,9 +2864,9 @@ def process_single_collector(st):
     if isinstance(st, PgstatCollector):
         st.set_aux_processes_filter(filter_aux)
     st.tick()
-    if st.needs_refresh() and not freeze:
-        st.refresh()
     if not freeze:
+        if st.needs_refresh():
+            st.refresh()
         if st.needs_diffs():
             st.diff()
         else:

--- a/pg_view.py
+++ b/pg_view.py
@@ -3434,7 +3434,7 @@ def main():
                 logger.error('PostgreSQL exception {0}'.format(e))
                 pgcon = None
             if pgcon:
-                desc = make_cluster_desc(name=dbname, ver=dbver, workdir=result_work_dir,
+                desc = make_cluster_desc(name=dbname, version=dbver, workdir=result_work_dir,
                                          pid=ppid, pgcon=pgcon, conn=conn)
                 clusters.append(desc)
     collectors = []

--- a/pg_view.py
+++ b/pg_view.py
@@ -3164,10 +3164,11 @@ def establish_user_defined_connection(instance, conn, clusters):
         we use port, host and socket_directory, prefering socket over TCP connections
     """
 
-    pgcon = None
-    # establish a new connection
     def reconnect():
         return psycopg2.connect(**conn)
+
+    pgcon = None
+    # establish a new connection
     try:
         pgcon = reconnect()
     except Exception as e:
@@ -3409,6 +3410,7 @@ def main():
                 host = conndata['host']
                 port = conndata['port']
                 conn = build_connection(host, port, options.username, options.dbname)
+
                 def reconnect():
                     return psycopg2.connect(**conn)
                 pgcon = reconnect()

--- a/pg_view.py
+++ b/pg_view.py
@@ -1193,8 +1193,7 @@ class PgstatCollector(StatCollector):
                 self.pgcon, self.postmaster_pid = self.reconnect()
                 self.connection_pid = self.pgcon.get_backend_pid()
                 self.max_connections = self._get_max_connections()
-            else:
-                stat_data = self._read_pg_stat_activity()
+            stat_data = self._read_pg_stat_activity()
         except psycopg2.OperationalError as e:
             logger.info("failed to query the server: {}".format(e))
             if self.pgcon and not self.pgcon.closed:


### PR DESCRIPTION
This allows us not to die miserably on server restart, but continue to
collect the other stats like memory, cpu and disk usage.  On every
round we will try to reconnect and will be displaying the PG stats as
soon as the server is back online.