### PR TITLE
Fix handling of database name in config.ini file

### DIFF
--- a/pg_view.py
+++ b/pg_view.py
@@ -3356,7 +3356,7 @@ def main():
             host = config[instance].get('host')
             port = config[instance].get('port')
             conn = build_connection(host, port,
-                                    config[instance].get('user'), config[instance].get('database'))
+                                    config[instance].get('user'), config[instance].get('dbname'))
 
             if not establish_user_defined_connection(instance, conn, clusters):
                 logger.error('failed to acquire details about ' +


### PR DESCRIPTION
The readme doc says it should be 'dbname', but the code used
'database' instead.  Thanks psycopg2 for being consistent ;-)