### PR TITLE
README edits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-pg_view: PostgreSQL Real-Time Activity View Utility
+pg_view: Postgres Real-Time Activity View Utility
 =======
 
 .. image:: https://travis-ci.org/zalando/pg_view.svg?branch=master
@@ -100,43 +100,23 @@ pg_view supports three output methods:
 
 Descriptions of some of the options:
 
-- system
-    - **ctxt**: the number of context switches in the system
-    - **iowait**: the percent of the CPU resources waiting on I/O
-    - **run, block**: the number of running and waiting processes
-    - For other parameters, please, refer to man 5 proc and look for /proc/stat
-* memory
-    * dirty
-            the total amount of memory waiting to be written on disk.
-            The higher the value is, the more one has to wait during the flush.
-    * as
-            (CommittedAs) the total amount of memory required to store the workload
-            in the worst case scenario.
-    * limit
-            maximum amount of memory that can be physically allocated. If ``as`` is higher
-            than the ``limit`` - the processes will start getting out of memory errors,
-            which will lead to PostgreSQL shutdown (but not to the data corruption.
-
-      For the explanation of other parameters, please, refer to the
-      `Linux kernel documentation <http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/proc.txt>`_
-
-* partitions
-    * type
-            either containing database data (data) or WAL (xlog)
-    * fill
-            the rate of adding new data to the corresponding directory (``/data`` or ``/pg_xlog``).
-    * until_full
-            the time until the current partition will run out of space if we only consider writes
-            to the corresponding data directory (``/data`` or ``/pg_xlog``). This column is only shown
-            during the warning (3h) or critical (1h) conditions. This column only considers momentary
-            writes, so if a single process writes 100MB/s on a partition with remaining 100GB left for
-            only 2 seconds, it will show a critial status during those 2 seconds.
-    * total, left, read, write
-            the amount of space total, free, read and write rate (MB/s) on a partition. Note that write rate is different from
-            fill rate: it considers the whole partition, not only Postgres directories and shows data modifications, i.e deletion of files at the rate of 10MB/s will be shown as a positive write rate.
-    * path_size
-            size of the corresponding PostgreSQL directory.
-
+- **system**
+    - **ctxt**: the number of context switches in the system.
+    - **iowait**: the percent of the CPU resources waiting on I/O.
+    - **run, block**: the number of running and waiting processes.
+    - For other parameters, please refer to man 5 proc and look for /proc/stat.
+- **memory**
+    - **as** (CommittedAs): the total amount of memory required to store the workload in the worst-case scenario (i.e., if all applications actually allocate all the memory they ask for during the startup).
+    - **dirty**: the total amount of memory waiting to be written on-disk. The higher the value, the more one has to wait during the flush.
+    - **limit**: the maximum amount of memory that can be physically allocated. If memory exceeds the limit, you will start seeing “out of memory” errors, which will lead to a PostgreSQL shutdown.
+    - For an explanation of other parameters, please refer to the `Linux kernel documentation <http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/proc.txt>`_.
+- **partitions**
+    - **fill**: the rate of adding new data to the corresponding directory (``/data`` or ``/pg_xlog``).
+    - **path_size**: the size of the corresponding PostgreSQL directory.
+    - **total, left, read, write**: the amount of disk space available and allocated, as well as the read and write rates (MB/s) on a given partition. Write rate is different from fill rate, in that it considers the whole partition, not only the Postgres directories. Also, it shows data modifications. File deletion at the rate of 10MB/s will be shown as a positive write rate.
+    - **type**: either containing database data (data) or WAL (xlog).
+    - **until_full**: the time remaining before the current partition will run out of space, *if* we only consider writes to the corresponding data directory (``/data`` or ``/pg_xlog``). This column is only shown during the warning (3h) or critical (1h) conditions, and only considers momentary writes. If a single process writes 100MB/s on a partition with 100GB left for only two seconds, it will show a critical status during those two seconds.
+  
 * postgres processes
     * type
             either a system process (autovacuum launcher, logger, archiver, etc) or a process that

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ The special 'DEFAULT' section contains the parameters that apply for every datab
 
 Upon reading this file, the application will try using port 5435 (database postgres) to connect to both testdb and testdb2 clusters, and—using the database name ‘test’—port 5433 to connect to testdb3.
 
-If the auto-detection code works for you, you can select a single database by specifying the database instance name (in most cases, it will match the last component of $PGDATA) with the ``-i`` command-line option. If there are more than a single instance with the same name, you can additionally specify the required PG version with ``-V``.
+If the auto-detection code works for you, you can select a single database by specifying the database instance name (in most cases, it will match the last component of $PGDATA) with the ``-i`` command-line option. If there is more than a single instance with the same name, you can additionally specify the required PG version with ``-V``.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ pg_view: PostgreSQL Real-Time Activity View Utility
 Intro
 --------
 
-**pg_view** is a powerful command-line tool that offers a detailed, real-time view of your PostgreSQL database and system metrics. It combines the indicators commonly displayed by sar or iostat with output from PostgreSQL’s process activity view, and presents global and per-process statistics in an easy-to-interpret way. 
+**pg_view** is a powerful command-line tool that offers a detailed, real-time view of your PostgreSQL database and system metrics. It combines the indicators commonly displayed by sar or iostat with output from PostgreSQL’s process activity view, and presents global and per-process statistics in an easy-to-interpret way.
 
 pg_view shows these types of data:
 
@@ -49,24 +49,23 @@ pg_view queries system/process information files once per second. It also runs e
 Connection Arguments
 --------------------
 
-By default, pg_view tries to autodetect all PostgreSQL clusters running on the host it's running at. To achieve
-this it performs the following steps:
+By default, pg_view tries to autodetect all PostgreSQL clusters running on the same host by performing the following steps (in order):
 
-* read /proc/ filesystem and detect pid files for the postmaster processes
-* get the working directories from the symlink at /proc/pid/cwd
-* get to the working directories and read PG_VERSION for PostgreSQL verions. If we can't, assume it's not a PostgreSQL directory and skip.
-* try to get all sockets the process is listening to from /proc/net/unix, /proc/net/tcp and /proc/net/tcp6
-* if that fails and version is 9.1 or above, read connection arguments from postmaster.pid
-* check all arguments, picking the first one that allows us to establish a connection
-* if we can't get either the port/host or port/socket_directory pair, bail out.
+- reads /proc/ filesystem and detects pid files for the postmaster processes
+- gets the working directories from the symlink at /proc/pid/cwd
+- reads the PG_VERSION for PostgreSQL versions (If it doesn’t, assume it's not a PostgreSQL directory, and skip)
+- tries to collect from /proc/net/unix, /proc/net/tcp and /proc/net/tcp6 all the sockets the process is listening to
+    - if that fails, and you are using version 9.1 or above, reads the connection arguments from postmaster.pid
+- checks all arguments, picking the first that allows it to establish a connection
+- if pg_view can't get either the port/host or port/socket_directory pair, bail out
 
-If the program is unable to detect connection arguments using the algorithm above it's possible to specify
-those arguments manually using the configuration file supplied with -c option. This file should consist of
-one or more sections, containing key = value pairs. Each section's title represents a database cluster name,
-this name is only used to for display purposes (the actual name of the DB to connect to can be specified by the dbname parameter and is 'postgres' by default), and the key - value pairs should contain connection parameters. The valid keys are:
+If the program can’t detect your connection arguments using the algorithm above, you can specify those arguments manually using the configuration file supplied with the -c option. This file should consist of one or more sections, each containing a key = value pair.
 
-host
-    hostname or ip address, or unix_socket_directory path of the database server
+The title of each section represents a database cluster name (this name is for display purposes only). The dbname parameter is “postgres” by default, and specifies the actual name of the database to connect to. The key-value pairs should contain connection parameters. 
+
+**The valid keys are:**
+
+- **host**: hostname or ip address, or unix_socket_directory path of the database server
 
 port
     the port the database server listsens on

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-pg_view
+pg_view: PostgreSQL Real-Time Activity View Utility
 =======
 
 .. image:: https://travis-ci.org/zalando/pg_view.svg?branch=master
@@ -11,15 +11,20 @@ pg_view
       :target: https://pypi.python.org/pypi/pg-view
       :alt: License
 
-PostgreSQL Activity View Utility
 
-Synopsis
+Intro
 --------
 
-``pg_view`` is a command-line tool to display the state to the PostgreSQL processes.
-It shows the per-process statistics combined with ``pg_stat_activity`` output for the processes
-that have the rows there, global system stats, per-partition information and the memory stats.
-You can find a blog post about it at `tech.zalando.com <https://tech.zalando.com/blog/getting-a-quick-view-of-your-postgresql-stats/>`_.
+**pg_view** is a powerful command-line tool that offers a detailed, real-time view of your PostgreSQL database and system metrics. It combines the indicators commonly displayed by sar or iostat with output from PostgreSQL’s process activity view, and presents global and per-process statistics in an easy-to-interpret way. 
+
+pg_view shows these types of data:
+
+- per-process statistics, combined with ``pg_stat_activity`` view output for the backend and autovacuum processes
+- global system stats
+- per-partition information
+- memory stats
+
+pg_view can be especially helpful when you’re monitoring system load, query locks and I/O utilization during lengthy data migrations. It’s also useful when you’re running servers 24x7 and aiming for zero downtime. Learn more about it at `tech.zalando.com <https://tech.zalando.com/blog/getting-a-quick-view-of-your-postgresql-stats/>`_.
 
 Requirements
 ------------

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,7 @@ By default, pg_view tries to autodetect all PostgreSQL clusters running on the s
 - reads /proc/ filesystem and detects pid files for the postmaster processes
 - gets the working directories from the symlink at /proc/pid/cwd
 - reads the PG_VERSION for PostgreSQL versions (If it doesn’t, assume it's not a PostgreSQL directory, and skip)
-- tries to collect from /proc/net/unix, /proc/net/tcp and /proc/net/tcp6 all the sockets the process is listening to
-    * if that fails, and you are using version 9.1 or above, reads the connection arguments from postmaster.pid
+- tries to collect from /proc/net/unix, /proc/net/tcp and /proc/net/tcp6 all the sockets the process is listening to. If that fails, and you are using version 9.1 or above, reads the connection arguments from postmaster.pid
 - checks all arguments, picking the first that allows it to establish a connection
 - if pg_view can't get either the port/host or port/socket_directory pair, bail out
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,11 @@ pg_view shows these types of data:
 
 pg_view can be especially helpful when you’re monitoring system load, query locks and I/O utilization during lengthy data migrations. It’s also useful when you’re running servers 24x7 and aiming for zero downtime. Learn more about it at `tech.zalando.com <https://tech.zalando.com/blog/getting-a-quick-view-of-your-postgresql-stats/>`_.
 
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
 Installation and Configuration
 ------------
 
@@ -100,11 +105,6 @@ pg_view supports three output methods:
 
 Descriptions of some of the options:
 
-- **system**
-    - **ctxt**: the number of context switches in the system.
-    - **iowait**: the percent of the CPU resources waiting on I/O.
-    - **run, block**: the number of running and waiting processes.
-    - For other parameters, please refer to man 5 proc and look for /proc/stat.
 - **memory**
     - **as** (CommittedAs): the total amount of memory required to store the workload in the worst-case scenario (i.e., if all applications actually allocate all the memory they ask for during the startup).
     - **dirty**: the total amount of memory waiting to be written on-disk. The higher the value, the more one has to wait during the flush.
@@ -124,6 +124,11 @@ Descriptions of some of the options:
     - **s**: process state. ``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep'; see ``man ps`` for more details.
     - **type**: either a system process (autovacuum launcher, logger, archiver, etc.) or a process that executes queries (backend or autovacuum). By default, only user processes are shown in curses mode (press 's' to show all of them), and all in the console one.
     - **utime, stime, guest**: consumption of CPU resources by process. PostgreSQL backends can't use more than one CPU, so the percentage of a single CPU time is shown here.
+- **system**
+    - **ctxt**: the number of context switches in the system.
+    - **iowait**: the percent of the CPU resources waiting on I/O.
+    - **run, block**: the number of running and waiting processes.
+    - For other parameters, please refer to man 5 proc and look for /proc/stat.
 
 Hotkeys:
 --------

--- a/README.rst
+++ b/README.rst
@@ -121,8 +121,7 @@ Descriptions of some of the options:
     - **db**: the database the process runs on.
     - **query**: the query the process executes.
     - **read, write**: The amount of data read or written from the partition in MB/s.
-    - **s**: process state. ``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep'; see ``man ps``
-            for more details.
+    - **s**: process state. ``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep'; see ``man ps`` for more details.
     - **type**: either a system process (autovacuum launcher, logger, archiver, etc.) or a process that executes queries (backend or autovacuum). By default, only user processes are shown in curses mode (press 's' to show all of them), and all in the console one.
     - **utime, stime, guest**: consumption of CPU resources by process. PostgreSQL backends can't use more than one CPU, so the percentage of a single CPU time is shown here.
 

--- a/README.rst
+++ b/README.rst
@@ -116,45 +116,34 @@ Descriptions of some of the options:
     - **total, left, read, write**: the amount of disk space available and allocated, as well as the read and write rates (MB/s) on a given partition. Write rate is different from fill rate, in that it considers the whole partition, not only the Postgres directories. Also, it shows data modifications. File deletion at the rate of 10MB/s will be shown as a positive write rate.
     - **type**: either containing database data (data) or WAL (xlog).
     - **until_full**: the time remaining before the current partition will run out of space, *if* we only consider writes to the corresponding data directory (``/data`` or ``/pg_xlog``). This column is only shown during the warning (3h) or critical (1h) conditions, and only considers momentary writes. If a single process writes 100MB/s on a partition with 100GB left for only two seconds, it will show a critical status during those two seconds.
-  
-* postgres processes
-    * type
-            either a system process (autovacuum launcher, logger, archiver, etc) or a process that
-            executes queries (backend or autovacuum). By default, only user processes are shown (press
-            's' to show all of them) in curses mode, and all in the console one.
-    * s
-            process state (``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep', see ``man ps``
+- **postgres processes**
+    - **age**: length of time since the process started.
+    - **db**: the database the process runs on.
+    - **query**: the query the process executes.
+    - **read, write**: The amount of data read or written from the partition in MB/s.
+    - **s**: process state (``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep'; see ``man ps``
             for more details).
-    * utime, stime, guest
-            consumption of CPU resources by process. Since PostgreSQL backends can't use more than one
-            CPU, the percentage of a single CPU time is shown here.
-    * read, write
-            amount of data read or written from the partition (in MB/s).
-    * age
-            time from the process start
-    * db
-            the database the process runs on
-    * query
-            the query the process executes.
-
+    - **type**: either a system process (autovacuum launcher, logger, archiver, etc.) or a process that executes queries (backend or autovacuum). By default, only user processes are shown in curses mode (press 's' to show all of them), and all in the console one.
+    - **utime, stime, guest**: consumption of CPU resources by process. PostgreSQL backends can't use more than one CPU, so the percentage of a single CPU time is shown here.
 
 Hotkeys:
+--------
 
-* f
-    instantly freeze the output. Press ``f`` for the second time to resume.
-* u
+- **a**: auto-hide fields from the PostgreSQL output. Turning on this option hides the following fields: ``type``, ``s``, ``utime``, ``stime``, ``guest``.
+- **f**: instantly freezes the output. Press ``f`` a second time to resume.
+- **h**: shows the help screen.
+- **u**: toggle display of measurement units.
     toggle display of measurement units.
-* a
-    auto-hide some of the fields from the PostgreSQL output. Currently, if this option is turned to on, the following fields can
-    be hidden to leave space for the remaining ones: ``type``, ``s``, ``utime``, ``stime``, ``guest``
-* h
-    show the help screen
 
 Releasing
 ---------
 
     $ ./release.sh <NEW-VERSION>
 
+Contributing
+---------
+
+pg_view welcomes contributions; simply make a pull request.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -26,25 +26,27 @@ pg_view shows these types of data:
 
 pg_view can be especially helpful when you’re monitoring system load, query locks and I/O utilization during lengthy data migrations. It’s also useful when you’re running servers 24x7 and aiming for zero downtime. Learn more about it at `tech.zalando.com <https://tech.zalando.com/blog/getting-a-quick-view-of-your-postgresql-stats/>`_.
 
-Requirements
+Installation and Configuration
 ------------
 
-Linux 2.6, python 2.6, psycopg2, curses
+To run pg_view, you’ll need:
 
-By default, pg_view assumes it's able to connect to the local PostgreSQL instance with the user postgres and no password. On some systems it might be necessary to change your pg_hba.conf or set the password in .pgpass. A different user name can be specified in the configuration file, although specifying that file (with -c) turns off autodetection of connection parameters and available databases.
+- Linux 2.6
+- Python >= 2.6
+- psycopg2
+- curses
 
-How it works:
+By default, pg_view assumes that it can connect to a local PostgreSQL instance with the user postgres and no password. Some systems might require you to change your pg_hba.conf file or set the password in .pgpass. You can use (-c) to specify a different user name in the configuration file, although specifying the file will turn off autodetection of connection parameters and available databases.
 
-The program queries system /process information files once every tick (by default the tick is 1s). It also
-runs some external programs, like df or du to get filesystem information. The latter might put an extra
-load on a disk subsystem.
+How pg_view Works:
+------------
 
-Screenshot
------------
+pg_view queries system/process information files once per second. It also runs external programs — df, du, etc. — to obtain filesystem information. Please note that the latter function might add an extra load to your disk subsystem.
+
 .. image:: https://raw.github.com/zalando/pg_view/master/images/pg_view_screenshot.png
    :alt: pg_view screenshot
 
-Connection arguments
+Connection Arguments
 --------------------
 
 By default, pg_view tries to autodetect all PostgreSQL clusters running on the host it's running at. To achieve

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ By default, pg_view tries to autodetect all PostgreSQL clusters running on the s
 - gets the working directories from the symlink at /proc/pid/cwd
 - reads the PG_VERSION for PostgreSQL versions (If it doesn’t, assume it's not a PostgreSQL directory, and skip)
 - tries to collect from /proc/net/unix, /proc/net/tcp and /proc/net/tcp6 all the sockets the process is listening to
-    - if that fails, and you are using version 9.1 or above, reads the connection arguments from postmaster.pid
+    * if that fails, and you are using version 9.1 or above, reads the connection arguments from postmaster.pid
 - checks all arguments, picking the first that allows it to establish a connection
 - if pg_view can't get either the port/host or port/socket_directory pair, bail out
 

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,6 @@ Hotkeys:
 - **f**: instantly freezes the output. Press ``f`` a second time to resume.
 - **h**: shows the help screen.
 - **u**: toggle display of measurement units.
-    toggle display of measurement units.
 
 Releasing
 ---------

--- a/README.rst
+++ b/README.rst
@@ -66,15 +66,10 @@ The title of each section represents a database cluster name (this name is for d
 **The valid keys are:**
 
 - **host**: hostname or ip address, or unix_socket_directory path of the database server
+- **port**: the port the database server listens to
+- **user**: the database role name
 
-port
-    the port the database server listsens on
-
-user
-    database role name
-
-The special 'DEFAULT' contains the parameters that apply for every database cluster if the corresponding parameter
-is missing from the database-specific section. For instance::
+The special 'DEFAULT' section contains the parameters that apply for every database cluster if the corresponding parameter is missing from the database-specific section. For instance::
 
     [DEFAULT]
     port=5435
@@ -90,31 +85,26 @@ is missing from the database-specific section. For instance::
     port=5433
     dbname=test
 
-The application will try to connect to both testdb and testdb2 clusters using port 5435 (database postgres) upon reading this file, while testdb3 will be reached using port 5433 and database name 'test'.
+Upon reading this file, the application will try using port 5435 (database postgres) to connect to both testdb and testdb2 clusters, and—using the database name ‘test’—port 5433 to connect to testdb3.
 
-Finally, if the auto-detection code works for you, it's possible to select only a single database by specifying
-the database instance name (in most cases mathes the last component of $PGDATA) with ``-i`` command-line option. If there are more thana single instance with the same name - you can additionally specify the required PG version with ``-V``.
+If the auto-detection code works for you, you can select a single database by specifying the database instance name (in most cases, it will match the last component of $PGDATA) with the ``-i`` command-line option. If there are more than a single instance with the same name, you can additionally specify the required PG version with ``-V``.
 
 Usage
 -----
 see ``python pg_view --help``
 
-Output:
-The tool supports 3 output methods:
+pg_view supports three output methods:
 * ncurses (default)
 * console (``-o console``)
-* json (``-o json``).
+* json (``-o json``)
 
-Below is the description of some of the options:
+Descriptions of some of the options:
 
-* system
-    * iowait
-            the percent of the CPU resources waiting on I/O
-    * ctxt
-            the number of context switches in the system
-    * run, block
-            the number of running and waiting processes.
-    * For other parameters, please, refer to man 5 proc and look for /proc/stat
+- system
+    - **ctxt**: the number of context switches in the system
+    - **iowait**: the percent of the CPU resources waiting on I/O
+    - **run, block**: the number of running and waiting processes
+    - For other parameters, please, refer to man 5 proc and look for /proc/stat
 * memory
     * dirty
             the total amount of memory waiting to be written on disk.

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ pg_view shows these types of data:
 
 pg_view can be especially helpful when you’re monitoring system load, query locks and I/O utilization during lengthy data migrations. It’s also useful when you’re running servers 24x7 and aiming for zero downtime. Learn more about it at `tech.zalando.com <https://tech.zalando.com/blog/getting-a-quick-view-of-your-postgresql-stats/>`_.
 
+Table of Contents
+--------
+
 .. contents::
     :local:
     :depth: 1

--- a/README.rst
+++ b/README.rst
@@ -121,8 +121,8 @@ Descriptions of some of the options:
     - **db**: the database the process runs on.
     - **query**: the query the process executes.
     - **read, write**: The amount of data read or written from the partition in MB/s.
-    - **s**: process state (``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep'; see ``man ps``
-            for more details).
+    - **s**: process state. ``R`` - 'running', ``S`` - 'sleeping', ``D`` - 'uninterruptable sleep'; see ``man ps``
+            for more details.
     - **type**: either a system process (autovacuum launcher, logger, archiver, etc.) or a process that executes queries (backend or autovacuum). By default, only user processes are shown in curses mode (press 's' to show all of them), and all in the console one.
     - **utime, stime, guest**: consumption of CPU resources by process. PostgreSQL backends can't use more than one CPU, so the percentage of a single CPU time is shown here.
 

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,9 @@ pg_view can be especially helpful when you’re monitoring system load, query lo
     :depth: 1
     :backlinks: none
 
+==============
 Installation and Configuration
-------------
+==============
 
 To run pg_view, you’ll need:
 
@@ -43,16 +44,18 @@ To run pg_view, you’ll need:
 
 By default, pg_view assumes that it can connect to a local PostgreSQL instance with the user postgres and no password. Some systems might require you to change your pg_hba.conf file or set the password in .pgpass. You can use (-c) to specify a different user name in the configuration file, although specifying the file will turn off autodetection of connection parameters and available databases.
 
+==============
 How pg_view Works:
-------------
+==============
 
 pg_view queries system/process information files once per second. It also runs external programs — df, du, etc. — to obtain filesystem information. Please note that the latter function might add an extra load to your disk subsystem.
 
 .. image:: https://raw.github.com/zalando/pg_view/master/images/pg_view_screenshot.png
    :alt: pg_view screenshot
 
+==============
 Connection Arguments
---------------------
+==============
 
 By default, pg_view tries to autodetect all PostgreSQL clusters running on the same host by performing the following steps (in order):
 
@@ -93,8 +96,10 @@ Upon reading this file, the application will try using port 5435 (database postg
 
 If the auto-detection code works for you, you can select a single database by specifying the database instance name (in most cases, it will match the last component of $PGDATA) with the ``-i`` command-line option. If there is more than a single instance with the same name, you can additionally specify the required PG version with ``-V``.
 
+==============
 Usage
------
+==============
+
 see ``python pg_view --help``
 
 pg_view supports three output methods:
@@ -130,25 +135,29 @@ Descriptions of some of the options:
     - **run, block**: the number of running and waiting processes.
     - For other parameters, please refer to man 5 proc and look for /proc/stat.
 
+==============
 Hotkeys:
---------
+==============
 
 - **a**: auto-hide fields from the PostgreSQL output. Turning on this option hides the following fields: ``type``, ``s``, ``utime``, ``stime``, ``guest``.
 - **f**: instantly freezes the output. Press ``f`` a second time to resume.
 - **h**: shows the help screen.
 - **u**: toggle display of measurement units.
 
+==============
 Releasing
----------
+==============
 
     $ ./release.sh <NEW-VERSION>
 
+==============
 Contributing
----------
+==============
 
 pg_view welcomes contributions; simply make a pull request.
 
+==============
 License
--------
+==============
 
 `Apache 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`_

--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,10 @@ Usage
 see ``python pg_view --help``
 
 pg_view supports three output methods:
-* ncurses (default)
-* console (``-o console``)
-* json (``-o json``)
+
+- ncurses (default)
+- console (``-o console``)
+- json (``-o json``)
 
 Descriptions of some of the options:
 


### PR DESCRIPTION
Just a few things: 

- Under "Install and Config section: "By default, pg_view assumes that it can connect to a local PostgreSQL instance with the user postgres and no password. Some systems might require you to change your pg_hba.conf file or set the password in .pgpass. You can use (-c) to specify a different user name in the configuration file." Should it be .... user "postgres" ? and should (-c) actually be in code format?

- Oleksii was interested in providing a screenshot update 

- Under "Usage," see python pg_view --help. A bit of context would be useful here, I think. 

- Under "postgres processes," "type": It ends with the words," all in the console one." That's a bit unclear.

