### PR TITLE
Connect using Connection Service File

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ By default, pg_view tries to autodetect all PostgreSQL clusters running on the s
 - checks all arguments, picking the first that allows it to establish a connection
 - if pg_view can't get either the port/host or port/socket_directory pair, bail out
 
-If the program can’t detect your connection arguments using the algorithm above, you can specify those arguments manually using the configuration file supplied with the -c option. This file should consist of one or more sections, each containing a key = value pair.
+If the program can’t detect your connection arguments using the algorithm above, you can specify those arguments manually using the configuration file supplied with the -c option. This file should consist of one or more sections, each containing a key = value pair. You can also use your Connection Service File.
 
 The title of each section represents a database cluster name (this name is for display purposes only). The dbname parameter is “postgres” by default, and specifies the actual name of the database to connect to. The key-value pairs should contain connection parameters. 
 

--- a/pg_view.py
+++ b/pg_view.py
@@ -3457,6 +3457,10 @@ def main():
             if not establish_user_defined_connection(instance, conn, clusters):
                 logger.error('failed to acquire details about ' +
                              'the database cluster {0}, the server will be skipped'.format(instance))
+    # connect using connection service file
+    elif options.instance:
+        if not establish_user_defined_connection(options.instance, {'service': options.instance}, clusters):
+            logger.error("unable to continue with cluster {0}".format(options.instance))
     elif options.host:
         port = options.port or "5432"
         # try to connet to the database specified by command-line options


### PR DESCRIPTION
For those who already have their Connection Service Files setup, it is useful not to have
to specify the configuration file.
By connection using the service=<name> format we delegate all the resolving of service file
locations to libpq.
