### PR TITLE
Show time when output was frozen.

### DIFF
--- a/pg_view/__init__.py
+++ b/pg_view/__init__.py
@@ -98,6 +98,7 @@ def poll_keys(screen, output):
         flags.display_units = flags.display_units is False
     if c == ord('f'):
         flags.freeze = flags.freeze is False
+        output.freeze_time = time.localtime() if flags.freeze else None
     if c == ord('s'):
         flags.filter_aux = flags.filter_aux is False
     if c == ord('h'):

--- a/pg_view/models/outputs.py
+++ b/pg_view/models/outputs.py
@@ -56,6 +56,7 @@ class CursesOutput(object):
         self.output_order = []
         self.show_help = False
         self.is_color_supported = True
+        self.freeze_time = None
 
         self._init_display()
 
@@ -119,6 +120,7 @@ class CursesOutput(object):
             self.help()
         # show clock if possible
         self.show_clock()
+        self.show_freeze_time()
         self.show_help_bar()
         self.screen.refresh()
         self.output_order = []
@@ -185,6 +187,20 @@ class CursesOutput(object):
         if clean:
             clock_str = time.strftime(self.CLOCK_FORMAT, time.localtime())
             self.screen.addnstr(0, self.screen_x - clock_str_len, clock_str, clock_str_len)
+
+    def show_freeze_time(self):
+        if not self.freeze_time:
+            return
+        freeze_time_len = len("Frozen at: ") + len(self.CLOCK_FORMAT)
+        clean = True
+        for pos in range(0, freeze_time_len):
+            x = self.screen.inch(1, self.screen_x - freeze_time_len - 1 + pos) & 255
+            if x != ord(' '):
+                clean = False
+                break
+        if clean:
+            freeze_time_str = "Frozen at: " + time.strftime(self.CLOCK_FORMAT, self.freeze_time)
+            self.screen.addnstr(1, self.screen_x - freeze_time_len, freeze_time_str, freeze_time_len)
 
     def _status_to_color(self, status, highlight):
         if status == COLSTATUS.cs_critical:


### PR DESCRIPTION
Solves https://github.com/zalando/pg_view/issues/45 (Adds an output with label freeze time).
![frozen](https://user-images.githubusercontent.com/12391372/36845632-8fbacb1a-1d7d-11e8-9d56-202cb1729aff.png)
